### PR TITLE
Add blog index route with mocked posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from "next/navigation";
+import { blogPosts } from "../posts";
+
+export default function BlogPost({ params }: { params: { slug: string } }) {
+  const post = blogPosts.find((p) => p.slug === params.slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-4">{post!.title}</h1>
+      <p className="text-gray-700 whitespace-pre-line">{post!.content}</p>
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,3 +1,25 @@
+import Link from "next/link";
+import { blogPosts } from "./posts";
+
 export default function Blog() {
-  return <div className="p-8">Blog page</div>;
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-8">Blog</h1>
+      <div className="space-y-8">
+        {blogPosts.map((post) => (
+          <article key={post.id} className="border-b pb-4">
+            <h2 className="text-xl font-semibold mb-2">
+              <Link href={`/blog/${post.slug}`} className="hover:underline text-blue-600">
+                {post.title}
+              </Link>
+            </h2>
+            <p className="text-gray-600 mb-2">{post.excerpt}</p>
+            <Link href={`/blog/${post.slug}`} className="text-blue-600 hover:underline">
+              Read more
+            </Link>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -1,0 +1,34 @@
+export type BlogPost = {
+  id: number;
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+};
+
+export const blogPosts: BlogPost[] = [
+  {
+    id: 1,
+    slug: "introducing-my-blog",
+    title: "Introducing My Blog",
+    excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, nunc sit amet varius cursus, nunc nisi luctus nisi, euismod aliquam nisl nunc eu massa.",
+  },
+  {
+    id: 2,
+    slug: "another-post",
+    title: "Another Post",
+    excerpt: "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    content:
+      "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+  },
+  {
+    id: 3,
+    slug: "yet-another-post",
+    title: "Yet Another Post",
+    excerpt: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+    content:
+      "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+  },
+];


### PR DESCRIPTION
## Summary
- implement /blog index page listing mocked posts
- add dynamic blog post route
- store mocked posts in a shared file

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684148a35e5083298a74e0f356838b04