### PR TITLE
Add global footer component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
       >
         <Navbar />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,36 +94,6 @@ export default function Home() {
         </section>
       </main>
 
-      {/* Footer */}
-      <footer className="py-8 bg-gray-900 text-white text-center">
-        <div className="flex flex-col items-center space-y-4 sm:flex-row sm:space-y-0 sm:space-x-6 mb-4">
-          <a href="#" aria-label="Twitter" className="hover:text-blue-400">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              className="w-6 h-6"
-            >
-              <path d="M8 19c11 0 16-9 16-16v-.7A11.3 11.3 0 0 0 26 0a11 11 0 0 1-3.1 1A5.4 5.4 0 0 0 25 0a11 11 0 0 1-3.4 1.3A5.5 5.5 0 0 0 12 6.5a15.7 15.7 0 0 1-11-6 5.5 5.5 0 0 0 1.7 7.4A5.3 5.3 0 0 1 1 7v.1a5.5 5.5 0 0 0 4.4 5.4 5.2 5.2 0 0 1-1.4.2 4.6 4.6 0 0 1-1-.1 5.5 5.5 0 0 0 5.1 3.8A11 11 0 0 1 0 18.6a15.7 15.7 0 0 0 8 2.4" />
-            </svg>
-          </a>
-          <a href="#" aria-label="GitHub" className="hover:text-gray-400">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              className="w-6 h-6"
-            >
-              <path
-                fillRule="evenodd"
-                d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-3 .7-3.7-1.5-3.7-1.5a2.9 2.9 0 0 0-1.2-1.5c-1-.8.1-.8.1-.8a2.3 2.3 0 0 1 1.7 1.2 2.3 2.3 0 0 0 3 1 2.3 2.3 0 0 1 .7-1.4c-2.4-.3-5-1.2-5-5.3a4.1 4.1 0 0 1 1.1-2.8 3.9 3.9 0 0 1 .1-2.8s.9-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1a3.9 3.9 0 0 1 .1 2.8 4 4 0 0 1 1.1 2.8c0 4.1-2.6 5-5 5.3a2.6 2.6 0 0 1 .8 2v3c0 .3.2.6.7.5A10 10 0 0 0 12 2"
-                clipRule="evenodd"
-              />
-            </svg>
-          </a>
-        </div>
-        <p>Contact: email@example.com</p>
-      </footer>
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+export default function Footer() {
+  const scrollToTop = () => {
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
+  return (
+    <footer className="bg-gray-100 dark:bg-gray-900 border-t py-6 mt-12">
+      <div className="container mx-auto px-4 text-center flex flex-col items-center space-y-4">
+        <div className="flex space-x-6">
+          <a
+            href="https://github.com/username"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+            className="hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12 2a10 10 0 00-3.162 19.495c.5.092.683-.217.683-.483v-1.704c-2.782.604-3.369-1.343-3.369-1.343-.454-1.15-1.11-1.458-1.11-1.458-.907-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.528 2.341 1.087 2.914.832.091-.647.35-1.087.636-1.337-2.22-.253-4.555-1.112-4.555-4.951 0-1.094.39-1.988 1.029-2.688-.103-.253-.447-1.272.098-2.65 0 0 .84-.269 2.75 1.025A9.564 9.564 0 0112 6.844a9.56 9.56 0 012.5.337c1.909-1.294 2.748-1.025 2.748-1.025.546 1.378.202 2.397.099 2.65.64.7 1.029 1.594 1.029 2.688 0 3.849-2.338 4.695-4.566 4.943.359.31.679.921.679 1.856v2.753c0 .269.181.58.688.481A10.001 10.001 0 0012 2z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </a>
+          <a
+            href="https://www.linkedin.com/in/username"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="LinkedIn"
+            className="hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                d="M4.98 3.5A2.5 2.5 0 002.5 6v12a2.5 2.5 0 002.48 2.5h14.04A2.5 2.5 0 0021.5 18V6a2.5 2.5 0 00-2.48-2.5H4.98zM8 18H5.5V9H8v9zm-1.25-10.25a1.25 1.25 0 110-2.5 1.25 1.25 0 010 2.5zM18.5 18h-2.5v-4.5c0-1.24-.51-2-1.56-2-.85 0-1.28.57-1.49 1.12-.08.2-.1.47-.1.74V18h-2.5V9H13v1.24c.36-.55 1.01-1.34 2.46-1.34 1.79 0 3.04 1.17 3.04 3.69V18z"
+              />
+            </svg>
+          </a>
+          <a
+            href="mailto:email@example.com"
+            aria-label="Email"
+            className="hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-6 h-6"
+            >
+              <path d="M1.5 4.5h21v15h-21v-15zM12 13.5l10.5-7.5h-21l10.5 7.5z" />
+            </svg>
+          </a>
+        </div>
+        <button
+          onClick={scrollToTop}
+          className="text-sm underline hover:text-blue-600"
+        >
+          Back to top
+        </button>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `Footer` component with GitHub, LinkedIn and email links
- include a "Back to top" button
- use the new footer from `layout.tsx`
- remove old footer from the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68416768558c8329bc970f0dc3ef484f