### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,8 +28,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased transition-colors duration-300`}
       >
+        <Script id="theme-init" strategy="beforeInteractive">
+          {`
+            const theme = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (theme === 'dark' || (!theme && prefersDark)) {
+              document.documentElement.classList.add('dark');
+            } else {
+              document.documentElement.classList.remove('dark');
+            }
+          `}
+        </Script>
         <Navbar />
         {children}
         <Footer />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const element = document.documentElement;
+    setIsDark(element.classList.contains("dark"));
+  }, []);
 
   const toggleMenu = () => {
     setIsOpen((prev) => !prev);
@@ -12,6 +18,19 @@ export default function Navbar() {
 
   const closeMenu = () => {
     setIsOpen(false);
+  };
+
+  const toggleTheme = () => {
+    const element = document.documentElement;
+    const newTheme = !isDark;
+    if (newTheme) {
+      element.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      element.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+    setIsDark(newTheme);
   };
 
   return (
@@ -39,7 +58,38 @@ export default function Navbar() {
             />
           </svg>
         </button>
-        <div className="hidden md:flex space-x-6">
+        <button
+          onClick={toggleTheme}
+          aria-label="Toggle dark mode"
+          className="md:hidden p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
+        >
+          {isDark ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                d="M12 3.1a1 1 0 01.993.883L13 4v2a1 1 0 01-1.993.117L11 6V4a1 1 0 011-1zM5.636 5.636a1 1 0 01.117 1.41l-1.414 1.414A1 1 0 012.93 6.93l1.414-1.414a1 1 0 011.292-.117zM12 16a4 4 0 100-8 4 4 0 000 8zm6.364-9.95a1 1 0 011.41 1.41l-1.414 1.415a1 1 0 01-1.528-1.282l.118-.128 1.414-1.415zM19 11a1 1 0 01.117 1.993L19 13h-2a1 1 0 01-.117-1.993L17 11h2zM6 11a1 1 0 01.117 1.993L6 13H4a1 1 0 01-.117-1.993L4 11h2zm11.657 6.657a1 1 0 011.41 0l1.414 1.414a1 1 0 01-1.41 1.415l-1.415-1.415a1 1 0 010-1.414zM4.222 17.071a1 1 0 011.415 1.414L4.222 19.9a1 1 0 01-1.415-1.414l1.415-1.415zM13 18v2a1 1 0 01-1.993.117L11 20v-2a1 1 0 011.993-.117L13 18z"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10.5 2.076A9 9 0 1121.924 13.5 7 7 0 0010.5 2.076zM12 20a8 8 0 100-16 8 8 0 000 16z"
+                clipRule="evenodd"
+              />
+            </svg>
+          )}
+        </button>
+        <div className="hidden md:flex space-x-6 items-center">
           <Link href="/" className="hover:underline">
             Home
           </Link>
@@ -55,6 +105,37 @@ export default function Navbar() {
           <Link href="/podcast" className="hover:underline">
             Podcast
           </Link>
+          <button
+            onClick={toggleTheme}
+            aria-label="Toggle dark mode"
+            className="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
+          >
+            {isDark ? (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-5 h-5"
+              >
+                <path
+                  d="M12 3.1a1 1 0 01.993.883L13 4v2a1 1 0 01-1.993.117L11 6V4a1 1 0 011-1zM5.636 5.636a1 1 0 01.117 1.41l-1.414 1.414A1 1 0 012.93 6.93l1.414-1.414a1 1 0 011.292-.117zM12 16a4 4 0 100-8 4 4 0 000 8zm6.364-9.95a1 1 0 011.41 1.41l-1.414 1.415a1 1 0 01-1.528-1.282l.118-.128 1.414-1.415zM19 11a1 1 0 01.117 1.993L19 13h-2a1 1 0 01-.117-1.993L17 11h2zM6 11a1 1 0 01.117 1.993L6 13H4a1 1 0 01-.117-1.993L4 11h2zm11.657 6.657a1 1 0 011.41 0l1.414 1.414a1 1 0 01-1.41 1.415l-1.415-1.415a1 1 0 010-1.414zM4.222 17.071a1 1 0 011.415 1.414L4.222 19.9a1 1 0 01-1.415-1.414l1.415-1.415zM13 18v2a1 1 0 01-1.993.117L11 20v-2a1 1 0 011.993-.117L13 18z"
+                />
+              </svg>
+            ) : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-5 h-5"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10.5 2.076A9 9 0 1121.924 13.5 7 7 0 0010.5 2.076zM12 20a8 8 0 100-16 8 8 0 000 16z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
       {isOpen && (
@@ -75,6 +156,37 @@ export default function Navbar() {
             <Link href="/podcast" className="hover:underline" onClick={closeMenu}>
               Podcast
             </Link>
+            <button
+              onClick={toggleTheme}
+              aria-label="Toggle dark mode"
+              className="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 self-start"
+            >
+              {isDark ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="w-5 h-5"
+                >
+                  <path
+                    d="M12 3.1a1 1 0 01.993.883L13 4v2a1 1 0 01-1.993.117L11 6V4a1 1 0 011-1zM5.636 5.636a1 1 0 01.117 1.41l-1.414 1.414A1 1 0 012.93 6.93l1.414-1.414a1 1 0 011.292-.117zM12 16a4 4 0 100-8 4 4 0 000 8zm6.364-9.95a1 1 0 011.41 1.41l-1.414 1.415a1 1 0 01-1.528-1.282l.118-.128 1.414-1.415zM19 11a1 1 0 01.117 1.993L19 13h-2a1 1 0 01-.117-1.993L17 11h2zM6 11a1 1 0 01.117 1.993L6 13H4a1 1 0 01-.117-1.993L4 11h2zm11.657 6.657a1 1 0 011.41 0l1.414 1.414a1 1 0 01-1.41 1.415l-1.415-1.415a1 1 0 010-1.414zM4.222 17.071a1 1 0 011.415 1.414L4.222 19.9a1 1 0 01-1.415-1.414l1.415-1.415zM13 18v2a1 1 0 01-1.993.117L11 20v-2a1 1 0 011.993-.117L13 18z"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="w-5 h-5"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10.5 2.076A9 9 0 1121.924 13.5 7 7 0 0010.5 2.076zM12 20a8 8 0 100-16 8 8 0 000 16z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              )}
+            </button>
           </div>
         </div>
       )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  darkMode: 'class',
+  content: [
+    './src/app/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- initialize theme based on localStorage
- add dark mode toggle button in navigation
- include smooth color transitions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684177588c088329b0b98252b159f432