### PR TITLE
Reverse podcast episode order

### DIFF
--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -21,7 +21,10 @@ export default function Podcast() {
         ></iframe>
       </div>
       <div className="space-y-6">
-        {episodes.map((episode) => (
+        {episodes
+          .slice()
+          .sort((a, b) => b.id - a.id)
+          .map((episode) => (
           <div key={episode.id} className="border-b pb-4">
             <h2 className="text-xl font-semibold mb-1">{episode.title}</h2>
             <p className="text-gray-600 dark:text-gray-300">{episode.description}</p>


### PR DESCRIPTION
## Summary
- display latest podcast episode first by sorting episodes descending by id

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841b440ec248329b51c2a9b3d5631e4