### PR TITLE
Revise site typography

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -22,7 +22,6 @@ export function generateStaticParams() {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function BlogPost({ params }: any) {
   const post = blogPosts.find((p) => p.slug === params.slug);
 
@@ -31,14 +30,14 @@ export default function BlogPost({ params }: any) {
   }
 
   return (
-    <div className="container mx-auto px-4 py-12">
-      <h1 className="text-3xl font-bold mb-4">{post!.title}</h1>
+    <div className="container mx-auto px-4 py-16 md:py-24 font-[family-name:var(--font-body)]">
+      <h1 className="text-4xl font-extrabold mb-6">{post!.title}</h1>
       <ReactMarkdown
         className="text-gray-700"
         components={{
-          h1: (props) => <h1 className="text-3xl font-bold mb-4" {...props} />,
-          h2: (props) => <h2 className="text-2xl font-semibold mb-3" {...props} />,
-          h3: (props) => <h3 className="text-xl font-semibold mb-2" {...props} />,
+          h1: (props) => <h1 className="text-4xl font-extrabold mb-4" {...props} />,
+          h2: (props) => <h2 className="text-3xl font-semibold mb-3" {...props} />,
+          h3: (props) => <h3 className="text-2xl font-semibold mb-2" {...props} />,
           p: (props) => <p className="mb-4 leading-relaxed" {...props} />,
           ul: (props) => <ul className="list-disc pl-6 mb-4" {...props} />,
           ol: (props) => <ol className="list-decimal pl-6 mb-4" {...props} />,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -11,12 +11,12 @@ export const metadata: Metadata = createMetadata({
 
 export default function Blog() {
   return (
-    <div className="container mx-auto px-4 py-12">
-      <h1 className="text-3xl font-bold mb-8">Blog</h1>
+    <div className="container mx-auto px-4 py-16 md:py-24 font-[family-name:var(--font-body)]">
+      <h1 className="text-4xl font-extrabold mb-10">Blog</h1>
       <div className="space-y-8">
         {blogPosts.map((post) => (
-          <article key={post.id} className="border-b pb-4">
-            <h2 className="text-xl font-semibold mb-2">
+          <article key={post.id} className="border-b pb-6">
+            <h2 className="text-2xl font-semibold mb-2">
               <Link href={`/blog/${post.slug}`} className="hover:underline text-blue-600">
                 {post.title}
               </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-body: var(--font-inter);
+  --font-heading: var(--font-poppins);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -24,8 +24,18 @@ html.dark {
   --foreground: #ededed;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading), sans-serif;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-body), Arial, Helvetica, sans-serif;
+  line-height: 1.6;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,20 @@
 import type { Metadata } from "next";
 import { createMetadata } from "@/lib/metadata";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Poppins } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { ThemeProvider } from "next-themes";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const poppins = Poppins({
+  weight: ["400", "600", "700"],
+  variable: "--font-poppins",
   subsets: ["latin"],
 });
 
@@ -30,7 +31,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased transition-colors duration-300`}
+        className={`${inter.variable} ${poppins.variable} antialiased transition-colors duration-300`}
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Navbar />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="container mx-auto px-4 py-24 text-center">
-      <h1 className="text-3xl font-bold mb-4">Page not found.</h1>
+    <div className="container mx-auto px-4 py-24 text-center font-[family-name:var(--font-body)]">
+      <h1 className="text-4xl font-extrabold mb-6">Page not found.</h1>
       <Link
         href="/"
         className="inline-block mt-4 px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,14 +16,14 @@ const blogPosts = [
 
 export default function Home() {
   return (
-    <div className="flex flex-col min-h-screen font-[family-name:var(--font-geist-sans)]">
+    <div className="flex flex-col min-h-screen font-[family-name:var(--font-body)]">
       {/* Hero Section */}
-      <header className="bg-gray-100 dark:bg-gray-900 py-12 md:py-20 text-center">
-        <h1 className="text-3xl md:text-5xl font-bold mb-4">Ege Erdağ</h1>
-        <p className="text-lg md:text-2xl mb-6">Designing and building things for the web</p>
+      <header className="bg-gray-100 dark:bg-gray-900 py-16 md:py-24 text-center">
+        <h1 className="text-4xl md:text-6xl font-extrabold mb-6">Ege Erdağ</h1>
+        <p className="text-xl md:text-2xl mb-8">Designing and building things for the web</p>
         <a
           href="#projects"
-          className="inline-block bg-blue-600 text-white px-4 md:px-6 py-2 md:py-3 rounded hover:bg-blue-700"
+          className="inline-block bg-blue-600 text-white px-6 md:px-8 py-3 md:py-4 rounded hover:bg-blue-700"
         >
           View My Work
         </a>
@@ -31,9 +31,9 @@ export default function Home() {
 
       <main className="flex-1">
         {/* About Section */}
-        <section id="about" className="py-12 md:py-16 container mx-auto px-4">
-          <h2 className="text-2xl font-semibold mb-4">About Me</h2>
-          <p className="text-gray-700 dark:text-gray-300">
+        <section id="about" className="py-16 md:py-24 container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">About Me</h2>
+          <p className="text-gray-700 dark:text-gray-300 mb-6">
             I&apos;m a driven software developer with experience in .NET, HTML/CSS, JavaScript, TypeScript and Python.
             I love creating intuitive, engaging web experiences and am interested in blending technology with thoughtful design.
             When I&apos;m not coding, I record a great podcast named Açık Büfe Diyalog.
@@ -41,9 +41,9 @@ export default function Home() {
         </section>
 
         {/* Projects Section */}
-        <section id="projects" className="py-12 md:py-16 bg-gray-50 dark:bg-gray-800">
+        <section id="projects" className="py-16 md:py-24 bg-gray-50 dark:bg-gray-800">
           <div className="container mx-auto px-4">
-            <h2 className="text-2xl font-semibold mb-8 text-center">Projects</h2>
+            <h2 className="text-3xl font-semibold mb-10 text-center">Projects</h2>
             <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
               <div className="border rounded p-6 bg-white dark:bg-gray-700">
                 <h3 className="font-semibold mb-2">Website Aegean</h3>
@@ -68,8 +68,8 @@ export default function Home() {
         </section>
 
         {/* Podcast Section */}
-        <section id="podcast" className="py-12 md:py-16 container mx-auto px-4">
-          <h2 className="text-2xl font-semibold mb-4">Podcast</h2>
+        <section id="podcast" className="py-16 md:py-24 container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Podcast</h2>
           <div className="h-[232px]">
             <iframe
               src="https://open.spotify.com/embed/show/5IkatgeB5ZBbbAADZC9Tty?utm_source=generator"
@@ -81,9 +81,9 @@ export default function Home() {
         </section>
 
         {/* Blog Preview Section */}
-        <section id="blog" className="py-12 md:py-16 bg-gray-50 dark:bg-gray-800">
+        <section id="blog" className="py-16 md:py-24 bg-gray-50 dark:bg-gray-800">
           <div className="container mx-auto px-4">
-            <h2 className="text-2xl font-semibold mb-8 text-center">
+            <h2 className="text-3xl font-semibold mb-10 text-center">
               Latest Blog Posts
             </h2>
             <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -10,8 +10,8 @@ export const metadata: Metadata = createMetadata({
 
 export default function Podcast() {
   return (
-    <div className="container mx-auto px-4 py-12">
-      <h1 className="text-3xl font-bold mb-8">Podcast</h1>
+    <div className="container mx-auto px-4 py-16 md:py-24 font-[family-name:var(--font-body)]">
+      <h1 className="text-4xl font-extrabold mb-10">Podcast</h1>
       <div className="mb-8 h-[232px]">
         <iframe
           src="https://open.spotify.com/embed/show/5IkatgeB5ZBbbAADZC9Tty?utm_source=generator"
@@ -25,8 +25,8 @@ export default function Podcast() {
           .slice()
           .sort((a, b) => b.id - a.id)
           .map((episode) => (
-          <div key={episode.id} className="border-b pb-4">
-            <h2 className="text-xl font-semibold mb-1">{episode.title}</h2>
+          <div key={episode.id} className="border-b pb-6">
+            <h2 className="text-2xl font-semibold mb-1">{episode.title}</h2>
             <p className="text-gray-600 dark:text-gray-300">{episode.description}</p>
           </div>
         ))}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -33,8 +33,8 @@ const projects: Project[] = [
 
 export default function Projects() {
   return (
-    <div className="container mx-auto px-4 py-12">
-      <h1 className="text-3xl font-bold mb-8">Projects</h1>
+    <div className="container mx-auto px-4 py-16 md:py-24 font-[family-name:var(--font-body)]">
+      <h1 className="text-4xl font-extrabold mb-10">Projects</h1>
       <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         {projects.map((project) => (
           <a
@@ -44,7 +44,7 @@ export default function Projects() {
             rel="noopener noreferrer"
             className="block border rounded p-6 bg-white dark:bg-gray-800 transition hover:shadow-lg hover:-translate-y-1"
           >
-            <h2 className="font-semibold text-xl mb-2">{project.title}</h2>
+            <h2 className="font-semibold text-2xl mb-2">{project.title}</h2>
             <p className="text-gray-600 dark:text-gray-300">
               {project.description}
             </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,8 +8,8 @@ export default function Footer() {
   };
 
   return (
-    <footer className="bg-gray-100 dark:bg-gray-900 border-t py-6 mt-12">
-      <div className="container mx-auto px-4 text-center flex flex-col items-center space-y-4">
+    <footer className="bg-gray-100 dark:bg-gray-900 border-t py-8 mt-16">
+      <div className="container mx-auto px-4 text-center flex flex-col items-center space-y-6 font-[family-name:var(--font-body)]">
         <div className="flex space-x-6">
           <a
             href="https://github.com/ErdagEge"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
   return (
     <nav className="bg-gray-100 dark:bg-gray-900 border-b">
       <div className="container mx-auto px-4 flex items-center justify-between h-16">
-        <Link href="/" className="text-xl font-semibold">
+        <Link href="/" className="text-2xl font-bold font-[family-name:var(--font-heading)]">
           MySite
         </Link>
         <button


### PR DESCRIPTION
## Summary
- use Inter for body text and Poppins for headings
- enlarge section spacing and heading sizes
- update pages and components for new fonts
- add extra whitespace for cleaner layout

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842f60fffa88329ba6485dc3830b142