### PR TITLE
Fix dark mode toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { Inter, Poppins } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import { ThemeProvider } from "next-themes";
+import ThemeProvider from "@/components/ThemeProvider";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
 const inter = Inter({
@@ -29,11 +29,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${inter.variable} ${poppins.variable} antialiased transition-colors duration-300`}
       >
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ThemeProvider>
           <Navbar />
           {children}
           <SpeedInsights />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,8 +6,8 @@ import { useTheme } from "next-themes";
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
-  const { resolvedTheme, setTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
 
   const toggleMenu = () => {
     setIsOpen((prev) => !prev);

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { PropsWithChildren } from "react";
+
+export default function ThemeProvider({ children }: PropsWithChildren) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemesProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add client `ThemeProvider` component
- wrap layout with new theme provider and suppress hydration warning
- simplify `Navbar` theme handling

## Testing
- `npm run lint`
- `npm run build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_684314e56c0c832982e90ac22c62715a